### PR TITLE
Remove filtro inicial de gestor

### DIFF
--- a/src/components/Contratos/TableContrato/index.jsx
+++ b/src/components/Contratos/TableContrato/index.jsx
@@ -24,7 +24,7 @@ export class TableContrato extends Component {
   }
 
   render() {
-    const { contratos, colunas } = this.props;
+    const { contratos, colunas, loading } = this.props;
     const total = contratos.reduce(
       (prevVal, value) => prevVal + value.total_mensal,
       0
@@ -57,7 +57,7 @@ export class TableContrato extends Component {
 
     return (
       <div className="h-auto w-100">
-        {this.props.contratos.length > 0 ? (
+        {this.props.contratos.length > 0 || loading ? (
           <DataTable
             onRowClick={e => this.redirecionaDetalhe(e.data)}
             value={this.props.contratos}
@@ -67,6 +67,7 @@ export class TableContrato extends Component {
             columnResizeMode="expand"
             className="mt-3 datatable-strapd-coad"
             selectionMode="single"
+            loading={loading}
           >
             {dynamicColumns}
           </DataTable>

--- a/src/pages/ContratosContinuos/index.jsx
+++ b/src/pages/ContratosContinuos/index.jsx
@@ -32,7 +32,7 @@ class ContratosContinuos extends Component {
         { field: "data_encerramento", header: "Data Encerramento" }
       ],
       filtros: {
-        gestor: getUsuario().user_id,
+        // gestor: getUsuario().user_id,
         empresa_contratada: "",
         encerramento_de: "",
         encerramento_ate: "",
@@ -41,7 +41,8 @@ class ContratosContinuos extends Component {
         situacao: "",
         termo_Contrato: "",
         tipo_servico: ""
-      }
+      },
+      loading: true
     };
   }
   async setaColunasDefaut() {
@@ -55,16 +56,20 @@ class ContratosContinuos extends Component {
     }
   }
 
-  setaMeusContratos() {
+  async setaMeusContratos() {
     const { filtros } = this.state;
-    getContratos(filtros).then(contratos => {
+    await getContratos(filtros).then(contratos => {
       this.setState({ contratos });
+    });
+    this.setState({
+      loading: false
     });
   }
 
   onBuscarClick = filtros => {
+    this.setState({ loading: true });
     getContratos(filtros).then(contratos => {
-      this.setState({ contratos, filtros });
+      this.setState({ contratos, filtros, loading: false });
     });
   };
 
@@ -90,7 +95,6 @@ class ContratosContinuos extends Component {
   };
 
   componentDidMount() {
-
     const param = getUrlParams();
     if (param.cadastro) {
       this.messages.show({
@@ -105,7 +109,7 @@ class ContratosContinuos extends Component {
   }
 
   render() {
-    const { contratos, colunas } = this.state;
+    const { contratos, colunas, loading } = this.state;
     return (
       <Page>
         <Messages ref={el => (this.messages = el)}></Messages>
@@ -140,7 +144,11 @@ class ContratosContinuos extends Component {
               }
             />
           </CoadAccordion>
-          <TableContrato contratos={contratos} colunas={colunas} />
+          <TableContrato
+            contratos={contratos}
+            colunas={colunas}
+            loading={loading}
+          />
         </Container>
       </Page>
     );


### PR DESCRIPTION
Esse PR:

- Busca todos os contratos por padrão em vez dos contratos do usuário;
- Adiciona loading na tabela de listagem no carregamento;