### PR TITLE
feature/9508-task9512-exibir-coluna-dres-contratos

### DIFF
--- a/src/components/Contratos/SelecionaColunasContrato/index.jsx
+++ b/src/components/Contratos/SelecionaColunasContrato/index.jsx
@@ -43,10 +43,6 @@ export class SelecionaColunasContrato extends Component {
           header: "Núcleo Responsável"
         },
         {
-          field: "objeto",
-          header: "Objeto"
-        },
-        {
           field: "data_assinatura",
           header: "Data Assinatura"
         },
@@ -71,8 +67,8 @@ export class SelecionaColunasContrato extends Component {
           header: "Suplente"
         },
         {
-          field: "observacoes",
-          header: "Observações"
+          field: "dres",
+          header: "DREs"
         }
       ],
       selectedCols: []


### PR DESCRIPTION
Esse PR:
- Adiciona a coluna DREs na consulta de contratos
- Remove as colunas objeto e observações da consulta de contratos.