### PR TITLE
feature/9518-task10015-ajustes-inclusao-contrato

### DIFF
--- a/src/pages/CadastrarContrato/index.jsx
+++ b/src/pages/CadastrarContrato/index.jsx
@@ -68,7 +68,7 @@ export default class CadastrarContrato extends Component {
       termo_contrato,
       gestor: gestor ? gestor.uuid : null,
       uuid_contrato: uuid,
-      coordenador: coordenador.uuid
+      coordenador: coordenador ? coordenador.uuid : null
     });
     $("#cancelar-contrato").click(function() {
       $(".form-cadastrar-contrato")

--- a/src/pages/CadastrarContrato/informacoes.jsx
+++ b/src/pages/CadastrarContrato/informacoes.jsx
@@ -54,7 +54,7 @@ export default class Informacoes extends Component {
       dataEncerramento: contrato.data_encerramento
         ? moment(contrato.data_encerramento).format("DD/MM/YYYY")
         : null,
-      cnpjEmpresa: contrato.empresa_contratada.cnpj
+      cnpjEmpresa: contrato.empresa_contratada ? contrato.empresa_contratada.cnpj : null
     });
     $("#avancar-1").click(e => {
       const situacaoRadio = $("[name=situacao]:checked").val();


### PR DESCRIPTION
Esse PR:
- Altera a inclusão de contratos  para considerar os campos vazios quando o TC não tiver coordenador ou empresa definidos.