### PR TITLE
feature/10297-notificacao-vigencia-assincrona

### DIFF
--- a/src/pages/PainelSelecao/index.jsx
+++ b/src/pages/PainelSelecao/index.jsx
@@ -8,7 +8,7 @@ import CardServico from "../../components/Contratos/CardServico";
 import { Button, ButtonGroup } from "reactstrap";
 import { Messages } from "primereact/messages";
 import { redirect } from "../../utils/redirect";
-import {getMinhasNotificacoesVigenciaContratos, geraNotificacoesVigenciaContratos} from "../../service/Notificacoes.service"
+import {getMinhasNotificacoesVigenciaContratos} from "../../service/Notificacoes.service"
 
 class PainelSelecao extends Component {
 
@@ -22,21 +22,15 @@ class PainelSelecao extends Component {
   
   
   async componentDidMount() {
-    // TODO Extrair a geração de notificações para um serviço assíncrono do Celery
-    geraNotificacoesVigenciaContratos().then(
-      async () => {
-        const minhasNotificacoesVigenciaContrato = await getMinhasNotificacoesVigenciaContratos()
 
-        if (minhasNotificacoesVigenciaContrato) {
-          this.setState({qtdContratosVencendo: minhasNotificacoesVigenciaContrato.contratos_vencendo})
-        }
-        
-        
-        this.exibeNotificacoesVigencia()
-      }
-    )
+    const minhasNotificacoesVigenciaContrato = await getMinhasNotificacoesVigenciaContratos()
 
+    if (minhasNotificacoesVigenciaContrato) {
+      this.setState({qtdContratosVencendo: minhasNotificacoesVigenciaContrato.contratos_vencendo})
+    }
     
+    this.exibeNotificacoesVigencia()
+
   }
 
   exibeNotificacoesVigencia() {
@@ -78,3 +72,4 @@ class PainelSelecao extends Component {
 }
 
 export default PainelSelecao;
+

--- a/src/service/Notificacoes.service.js
+++ b/src/service/Notificacoes.service.js
@@ -9,11 +9,3 @@ export const getMinhasNotificacoesVigenciaContratos = async () => {
   return (await api.get(url, AUTH_HEADER)).data
 }
 
-
-export const geraNotificacoesVigenciaContratos = async () => {
-  const AUTH_HEADER = {
-    headers: getHeaderToken()
-  };
-  const url = 'gera-notificacoes-vigencia-contratos/'
-  return (await api.get(url, AUTH_HEADER)).data
-}


### PR DESCRIPTION
Esse PR:
- Remove a chamada à API para geração de notificações de vigência.


As notificações de vigência passaram a ser geradas de forma assíncrona no backend. Não é mais necessário que o front acione a API para isso.