### PR TITLE
Passa a usar variavel de ambiente na url de equipamentos

### DIFF
--- a/src/configs/config.constants.js
+++ b/src/configs/config.constants.js
@@ -1,6 +1,9 @@
 export let API_URL;
 export let JWT_AUTH;
 export let ALIAS_TOKEN;
+export let SAFI_EQUIPAMENTOS_API_URL;
+
+SAFI_EQUIPAMENTOS_API_URL = process.env.REACT_APP_SAFI_EQUIPAMENTOS_API_URL;
 
 if (process.env.NODE_ENV === "production") {
   // This way we can pass params to static files. see Dockerfile.

--- a/src/service/Equipamentos.service.js
+++ b/src/service/Equipamentos.service.js
@@ -22,7 +22,7 @@ export const getEquipamentos = async ({
 }) => {
   const response = await getSafiToken();
   return await axios.get(
-    `https://hom-smecieduapi.sme.prefeitura.sp.gov.br/safi/equipamentos/` +
+    `${CONFIG.SAFI_EQUIPAMENTOS_API_URL}`+
       `?nm_equipamento=${nm_equipamento}` +
       `&cd_equipamento=${cd_equipamento}` +
       `&dre=${dre}` +


### PR DESCRIPTION
Este PR:

- Uma vez que a url estava desatualizada, foi implementado o uso de variável de ambiente. Facilitando a necessidade de alteração futura;